### PR TITLE
Fix that WebRequestMonitor.tabInfo is never removed

### DIFF
--- a/omega-target-chromium-extension/src/module/web_request_monitor.coffee
+++ b/omega-target-chromium-extension/src/module/web_request_monitor.coffee
@@ -128,8 +128,8 @@ module.exports = class WebRequestMonitor
     chrome.tabs.onCreated.addListener (tab) =>
       return unless tab.id
       @tabInfo[tab.id] = @_newTabInfo()
-    chrome.tabs.onRemoved.addListener (tab) =>
-      delete @tabInfo[tab.id]
+    chrome.tabs.onRemoved.addListener (tabId) =>
+      delete @tabInfo[tabId]
     chrome.tabs.onReplaced?.addListener (added, removed) =>
       @tabInfo[added] ?= @_newTabInfo()
       delete @tabInfo[removed]


### PR DESCRIPTION
tabInfo grows over time and extension is allocating more and more memory. chrome.tabs.onRemoved.addListener is getting integer tabId, not tab object.

### What does this PR do?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature

(Note: Translations and typo fixes should be done on https://hosted.weblate.org/projects/switchyomega/ instead of PR.)

Please explain the changes in details here...

#### Compatibility

Is this PR compatible with old versions? Can users simply upgrade the extension?
Please describe any possible breaking changes (or surprising UX differences).

#### Screenshots (if applicable)

---

After creating the PR:

- Please make sure the CircleCI test passes. Feel free to add more commits for
bug or style fixes.
- Any merge conflicts should be fixed on *your* side. Prefer rebasing to merging.
- Allow some time for project maintainers to review and merge the change.
- New features & behavior changes are subject to discussion. Please understand
that project maintainers may reject new features, or request changes.
